### PR TITLE
Updating to Arctic Fox (2020.3.1) Patch 4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   libfontconfig1 libgtk2.0-0 libxslt1.1 libxxf86vm1 \
   lib32stdc++6 libmagic1 libpulse0 \
   libglu1-mesa libgl1-mesa-dri mesa-utils libpci3 pciutils usbutils file \
+  && apt-get remove openjdk* \
+  && apt-get purge --auto-remove openjdk* \
+  && apt-get -y install openjdk-11-jdk \
   && rm -rf /var/lib/apt/lists/* \
   && useradd -ms /bin/bash developer \
 # required for the developer user to access /dev/kvm

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 # required for the developer user to access /dev/kvm
   && adduser developer root
 
-ARG studio_source=https://dl.google.com/dl/android/studio/ide-zips/3.4.1.0/android-studio-ide-183.5522156-linux.tar.gz
-ARG studio_local_dir=AndroidStudio3.4
+ARG studio_source=https://dl.google.com/dl/android/studio/ide-zips/2020.3.1.26/android-studio-2020.3.1.26-linux.tar.gz
+ARG studio_local_dir=AndroidStudio2020.3
 
 WORKDIR /opt/android-studio
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian
 
 LABEL maintainer "Viktor Adam <rycus86@gmail.com>"
+LABEL contributor="Chuba Oraka"
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
   gcc git openssh-client less curl ca-certificates zip unzip \

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Docker container to run Android Studio (https://developer.android.com/studio/ind
 
 ## Usage
 
-Run Android Studio with the files in the working directory by typing the following command:
+Run Android Studio with the files in the working directory by typing the following command:[^1]
 ```bash
 docker run -d --rm \
   --privileged \
@@ -28,7 +28,36 @@ Explanation:
 - `--privileged` - to have access to USB devices connected to the host .AndroidStudio* folders to keep the data on the host between different instances (like SDK tools, AVDs, etc.)
 - Local project directories need to be mounted into the container
 - The name can be anything - I used something random to be able to start multiple instances if needed
+- The `DISPLAY` variable has to be set before running the previous `docker run ...` command withn one of the following commands:[^2]
+
+>```bash
+>export DISPLAY=host.docker.internal$SCREEN
+>```
+
+>or
+
+>```bash
+>export DISPLAY=$(cat /etc/resolv.conf | grep nameserver | awk '{print $2; exit;}')$SCREEN
+>```
+
+>or
+
+>```bash
+>export DISPLAY=$(ip route | grep default | awk '{print $3}')$SCREEN
+>```
+
+- The `SCREEN` variable above depends on the platform on which the command is run. It can be set a using command similar to one of the following (the actual integer value after the colon may defer depending on your setup):
+
+
+>```bash
+>SCREEN=:0     # Linux
+>SCREEN=:0     # WSL on Windows with Xming installed
+>SCREEN=:0.0   # WSL on Windows with VcXsrv installed
+>```
 
 ## Notes
 
 The container has Git installed. It also has Kotlin installed. The container runs as a non-root user but that user is part of the root group to be able to use KVM. When Android Studio starts for the first time it might display a warning about KVM not working but it does actually.
+
+[^1]: More about setting the `DISPLAY` variable further in the document.
+[^2]: More about setting the `SCREEN` variable further in the document.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@ Docker container to run Android Studio (https://developer.android.com/studio/ind
 
 ## Usage
 
-```
-docker run --rm \
+Run Android Studio with the files in the working directory by typing the following command:
+```bash
+docker run -d --rm \
   --privileged \
   -e DISPLAY=${DISPLAY} \
   --device /dev/dri \
@@ -13,14 +14,13 @@ docker run --rm \
   -v /tmp/.X11-unix:/tmp/.X11-unix \
   -v /dev/bus/usb:/dev/bus/usb \
   -v /usr/share/X11/xkb:/usr/share/X11/xkb:ro \
-  -v ~/.AndroidStudio:/home/developer/.AndroidStudio \
-  -v ~/.AndroidStudio.android:/home/developer/.android \
   -v ~/.AndroidStudio.java:/home/developer/.java \
-  -v ~/.AndroidStudio.gradle:/home/developer/.gradle \
-  -v ~/.AndroidStudio.sdk:/home/developer/Android/Sdk \
-  -v ~/Project:/home/developer/Project \
-  --name androidstudio-$(head -c 4 /dev/urandom | xxd -p)-$(date +'%Y%m%d-%H%M%S') \
-rycus86/androidstudio:3.4
+  -v ~/.AndroidStudio.config:/home/developer/.config \
+  -v ~/.gradle:/home/developer/.gradle \
+  -v ~/Android/:/home/developer/Android/Sdk \
+  -v "$PWD:/home/developer/Project" \
+  --name androidstudio-$(head -c 4 /dev/urandom | xxd -p)-$(date +'%Y%m%d-%H%M%S')  \
+chubaoraka/docker-androidstudio:3.4.1.0
 ```
 
 Explanation:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ docker run -d --rm \
   -v ~/Android/:/home/developer/Android/Sdk \
   -v "$PWD:/home/developer/Project" \
   --name androidstudio-$(head -c 4 /dev/urandom | xxd -p)-$(date +'%Y%m%d-%H%M%S')  \
-chubaoraka/docker-androidstudio:3.4.1.0
+chubaoraka/docker-androidstudio
 ```
 
 Explanation:


### PR DESCRIPTION
The persistence of the Android Studio configuration is improved running the [new command](https://github.com/ChubaOraka/docker-androidstudio#user-content-fnref-1-2903f06f834b16f75e13da1852dc84f4). However, there seems to be a bug in the new version as I cannot type `ENTER` on the Android Studio terminal. I'm not sure whether this is a bug with the Android Studio version or something else.

I included the previous version in the [Docker builds](https://hub.docker.com/r/chubaoraka/docker-androidstudio/tags) and [tagged on GitHub](https://github.com/ChubaOraka/docker-androidstudio/tags) as appropriate.